### PR TITLE
Test allowing property assignment to named imports.

### DIFF
--- a/test/bundle/index.js
+++ b/test/bundle/index.js
@@ -129,7 +129,8 @@ module.exports = function () {
 			{ dir: '17', description: 'handles shadowed renamed imports' },
 			{ dir: '18', description: 'renames imports that conflict with existing variable names' },
 			{ dir: '19', description: 'handles hasOwnProperty edge case (default imports)' },
-			{ dir: '20', description: 'handles hasOwnProperty edge case (named imports)' }
+			{ dir: '20', description: 'handles hasOwnProperty edge case (named imports)' },
+			{ dir: '21', description: 'handles member assignments of named imports' }
 		];
 
 		profiles.forEach( function ( profile ) {

--- a/test/bundle/input/21/config.js
+++ b/test/bundle/input/21/config.js
@@ -1,0 +1,1 @@
+export const config = {};

--- a/test/bundle/input/21/main.js
+++ b/test/bundle/input/21/main.js
@@ -1,0 +1,2 @@
+import { config } from './config';
+config.async = true;


### PR DESCRIPTION
I spent a bit of time looking for how to fix this, but it wasn't obvious whether only `disallowIllegalReassignment` needed to change or if the scope of the change went beyond that. I ran into this while trying to build [RSVP](https://github.com/tildeio/rsvp.js) using esperanto.